### PR TITLE
project.pbxproj: Set valid architectures to `ARCHS_STANDARD`.

### DIFF
--- a/Objection.xcodeproj/project.pbxproj
+++ b/Objection.xcodeproj/project.pbxproj
@@ -1145,7 +1145,6 @@
 				PRODUCT_NAME = "Objection-StaticLib";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = "i386 x86_64 arm64 armv7s armv7";
 			};
 			name = Debug;
 		};
@@ -1168,7 +1167,6 @@
 				PRODUCT_NAME = "Objection-StaticLib";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = "i386 x86_64 arm64 armv7s armv7";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This solves the following sort of warnings:
`Mapping architecture arm64 to x86_64. Ensure that this target's
Architectures and Valid Architectures build settings are configured
correctly for the iOS Simulator platform.`